### PR TITLE
Improvements to gridDistance

### DIFF
--- a/+CMBHOME/@Session/gridDistance.m
+++ b/+CMBHOME/@Session/gridDistance.m
@@ -1,16 +1,21 @@
-function [d, ax] = gridDistance(self,Pd,ifplot)
+function [d, ax] = gridDistance(self,Pd,thresh,fromCenter,ifplot)
 % Calculates and returns the distance from the center Acorr peak to the
 %
 % Inputs: self -- CMBObject, function assumes self.cel is set
 %         Pd   -- "PeakDistance", the minimum distance between peaks.
 %         Defaults to 7, which works for most cells. Change if issues.
+%         thresh -- If nonempty, don't use peaks smaller than this value.
+%         fromCenter -- If false (default) compute from maximum peak; else compute from center peak.
 %         ifplot -- For debugging mostly. Defaults to 0
+
 %
 % Outputs: d -- The 6 distances (pixels).
 
 import CMBHOME.*
 
 if ~exist('Pd','var');Pd = 7;end
+if ~exist('thresh', 'var') || isempty(thresh), thresh = -inf; end
+if ~exist('fromCenter', 'var') || isempty(fromCenter), fromCenter = false; end
 
 rm = self.RateMap(self.cel);
 rmA = CMBHOME.Utils.moserac(rm);
@@ -18,13 +23,7 @@ rmA = CMBHOME.Utils.moserac(rm);
 [~,maxInds] = CMBHOME.Utils.extrema2(rmA); %linear index
 [rowInd colInd] = ind2sub(size(rmA),maxInds);
 
-rr = rowInd - rowInd(1);
-cr = colInd - colInd(1);
-
-d = sqrt(rr.^2 + rr.^2);
-
 %% Get rid of false peaks
-locs = sqrt(rowInd.^2+colInd.^2);
 
 peakHeight = NaN(length(rowInd),1);
 for i = 1:length(rowInd)
@@ -32,20 +31,15 @@ for i = 1:length(rowInd)
 end
 
 [peakHeight inds] = sort(peakHeight,'descend'); % May be unnecessary, seems like they come out in order
-rowInd = rowInd(inds);
-colInd = colInd(inds);
 
-
-idelete = zeros(size(peakHeight))<0; 
-for i = 1:length(peakHeight)
-    if ~idelete(i)
-        if i >1
-            for k = 1:i-1 %check to see if too close to any of the previous (larger) peaks
-                d(i,k) = sqrt((rowInd(i) - rowInd(k)).^2 + (colInd(i) -colInd(k)).^2);
-                if d(i,k) < Pd;
-                    idelete(i) = idelete(i)+1;
-                end
-            end
+idelete = peakHeight < thresh;
+for i = find(~idelete, 1):length(peakHeight)
+    ind1 = inds(i);
+    for k = 1:i-1 %check to see if too close to any of the previous (larger) peaks
+        ind2 = inds(k);
+        dist = sqrt((rowInd(ind1) - rowInd(ind2)).^2 + (colInd(ind1) -colInd(ind2)).^2);
+        if dist < Pd
+            idelete(i) = true;
         end
     end
 end
@@ -53,8 +47,21 @@ inds(idelete) = []; %indeces into rowInds and colInd
 
 %% Filter
 rowInd = rowInd(inds);
-colInd = colInd(inds);
-d = sqrt((rowInd - rowInd(1)).^2 + (colInd - colInd(1)).^2);
+colInd = colInd(inds); % now ordered from max to min peak that is still above thresh
+
+% identify the field for computing distance - either maximum or closest to center of arena
+if fromCenter
+    center = size(rmA) / 2;
+    dFromCenter = vecnorm([rowInd(:), colInd(:)] - center, 2, 2);
+    [~, ifield] = min(dFromCenter);
+    rowField = rowInd(ifield);
+    colField = colInd(ifield);
+else
+    rowField = rowInd(1);
+    colField = colInd(1);
+end
+
+d = sqrt((rowInd - rowField).^2 + (colInd - colField).^2);
 [d inds] = sort(d,'ascend');
 
 d = d(2:7);
@@ -63,8 +70,8 @@ d = d(2:7);
 
 
 %% Axes
-y = rowInd(inds(2:7)) - rowInd(inds(1));
-x = colInd(inds(2:7)) - colInd(inds(1));
+y = rowInd(inds(2:7)) - rowField;
+x = colInd(inds(2:7)) - colField;
 
 theta = atan2(x,y);
 


### PR DESCRIPTION
Fixes #9.

I was concerned about using `inds` of largest peaks to index `rowInd` and `colInd` twice - on lines 35-36 and again after removing peaks that are too close on 55-56. If `rowInd` and `colInd` are not initially in order of the largest to smallest peak, this could cause the peaks to become disordered.

However, after looking at it some more, since `rowInd` and `colInd` normally do start out sorted, I think the real problem for me was the lack of a peak threshold. So I added that in, as well as an option to measure from the peak at the center of the autocorrelation map.